### PR TITLE
Adds different sizes for pullquotes

### DIFF
--- a/src/css/module/_quote.scss
+++ b/src/css/module/_quote.scss
@@ -214,8 +214,6 @@ blockquote,
     margin-bottom: $base-line-height * 1em;
     color: $color-primary;
     font-family: $font-family-sans;
-  }
-  @include media($mid) {
     @include span-columns(3 of 7);
     @include shift(-1 of 7);
   }
@@ -230,7 +228,6 @@ blockquote,
     @include span-columns(4 of 7);
     @include shift(-2 of 7);
   }
-
 }
 
 // Pullquote in an blockquote

--- a/src/css/module/_quote.scss
+++ b/src/css/module/_quote.scss
@@ -208,7 +208,7 @@ blockquote,
     float: left;
     font-style: normal;
     font-weight: 900;
-    font-size: 1.25em;
+    font-size: 1em;
     width: 40%;
     margin-right: $gutter;
     margin-bottom: $base-line-height * 1em;
@@ -225,6 +225,8 @@ blockquote,
     @include shift(-2 of 7);
   }
   @include media($huge) {
+    font-size: 1.88em;
+    text-align: left;
     @include span-columns(4 of 7);
     @include shift(-2 of 7);
   }


### PR DESCRIPTION
Considering these different sizes for pullquotes, which helps the problem @rileycran and I discussed somewhat.

<img width="1192" alt="screenshot 2015-08-17 21 57 02" src="https://cloud.githubusercontent.com/assets/1581276/9322010/093a0fba-452b-11e5-8947-e95b53ce2e71.png">
<img width="1552" alt="screenshot 2015-08-17 21 57 04" src="https://cloud.githubusercontent.com/assets/1581276/9322011/093b730a-452b-11e5-977e-e39a3cb64533.png">
<img width="896" alt="screenshot 2015-08-17 21 57 08" src="https://cloud.githubusercontent.com/assets/1581276/9322014/093d8320-452b-11e5-8b30-6bea43244034.png">
<img width="896" alt="screenshot 2015-08-17 21 57 20" src="https://cloud.githubusercontent.com/assets/1581276/9322013/093d5ef4-452b-11e5-9a83-18790bffad1d.png">
<img width="1192" alt="screenshot 2015-08-17 21 57 31" src="https://cloud.githubusercontent.com/assets/1581276/9322012/093d32e4-452b-11e5-8e7a-a7bc248992e7.png">
<img width="1550" alt="screenshot 2015-08-17 21 57 32" src="https://cloud.githubusercontent.com/assets/1581276/9322015/093e54ee-452b-11e5-8eba-96dcfadf1391.png">
